### PR TITLE
bug(BLAZ-6829): Resolved the ListView samples related issue in VS2019

### DIFF
--- a/Pages/Layouts/Listview/CallHistory.razor
+++ b/Pages/Layouts/Listview/CallHistory.razor
@@ -2,7 +2,7 @@
 
 @using Syncfusion.Blazor.Lists;
 @using Syncfusion.Blazor.Navigations;
-
+@using blazor_samples.Pages.Layouts.ListView;
 @inherits SampleBaseComponent
 
 <SampleDescription>

--- a/Pages/Layouts/Listview/ListTemplates.razor
+++ b/Pages/Layouts/Listview/ListTemplates.razor
@@ -1,9 +1,7 @@
 ﻿@page "/listview/list-templates"
 @inject Microsoft.AspNetCore.Components.NavigationManager UriHelper
-
-
 @using Syncfusion.Blazor.Lists
-
+@using blazor_samples.Pages.Layouts.ListView;
 @inherits SampleBaseComponent
 
 <SampleDescription>


### PR DESCRIPTION
**Issue:** 
ListView samples compilation issue in the VS2019 preview.

**Cause:** 
Due to missing of model class in the razor page. it's throwing the compilation issue in the VS2019 Preview while compiling the Blazor sample browser samples.

**Solution:** 
Added the missed model class to the corresponding razor page. 

