### PR TITLE
Need to resolve "no white space characters before the XML declaration" error in web.config of Blazor WASM Hosted demos.

### DIFF
--- a/Blazor-WASM-Hosted-Demos/Server/web.config
+++ b/Blazor-WASM-Hosted-Demos/Server/web.config
@@ -1,4 +1,4 @@
-﻿﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <location path="." inheritInChildApplications="false">
     <system.webServer>


### PR DESCRIPTION
Root:
Need to resolve "no white space characters before the XML declaration" error in web.config of Blazor WASM Hosted demos.

Solution:
The "no white space characters before the XML declaration" error in web.config of Blazor WASM Hosted demos has been resolved.